### PR TITLE
Some changes about g8y/c8y/r8y and i4/i4g instance families

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -666,6 +666,8 @@ class TestExecutor():
         else:
             LOG.debug(f'Get user config "log_path": {log_path}')
 
+        if not os.path.exists(log_path):
+            os.mkdir(log_path)
         self.log_path = log_path
 
     def _run(self, flavor):

--- a/scheduler.py
+++ b/scheduler.py
@@ -308,6 +308,8 @@ Unsupported retry_counter_name ({retry_counter_name}), skip retry logic!')
                 [0, 11, 12, 13, 14, 15, 16, 21, 22, 23, 24, 31, 32, 33, 41])
         else:
             LOG.debug(f'Run task by command "{cmd}".')
+            if not os.path.exists(self.logpath):
+                os.mkdir(self.logpath)
             LOG.info(f'Saving log to "{self.logpath}/{logname}".')
             res = subprocess.run(cmd, shell=True)
             return_code = res.returncode

--- a/utils/provision_flavor_data.py
+++ b/utils/provision_flavor_data.py
@@ -74,14 +74,14 @@ def extract_info(spec):
         info['disk_type'] = spec.get('LocalStorageCategory')
 
     # Some special families use NVMe driver for local disks
-    _families = ['ecs.i3', 'ecs.i3g']
+    _families = ['ecs.i3', 'ecs.i3g', 'ecs.i4', 'ecs.i4g']
     if spec.get('InstanceTypeFamily') in _families:
         info['local_disk_driver'] = 'nvme'
     else:
         info['local_disk_driver'] = 'virtio_blk'
 
     # Some special families use NVMe driver for cloud disks
-    _families = ['ecs.g7se', 'ecs.ebmg7se']
+    _families = ['ecs.g7se', 'ecs.ebmg7se', 'ecs.g8y', 'ecs.c8y', 'ecs.r8y']
     if spec.get('InstanceTypeFamily') in _families:
         info['cloud_disk_driver'] = 'nvme'
     else:
@@ -99,7 +99,7 @@ def extract_info(spec):
     else:
         info['boot_mode'] = 'bios'
 
-    _families = ['ecs.g8m', 'ecs.g6r', 'ecs.c6r']
+    _families = ['ecs.g6r', 'ecs.c6r', 'ecs.g8y', 'ecs.c8y', 'ecs.r8y']
     if spec.get('InstanceTypeFamily') in _families:
         info['arch'] = 'aarch64'
     else:


### PR DESCRIPTION
1. Create the log dir if it doesn't exist
2. Add g8y/c8y/r8y which use NVMe clous disk
3. Add i4/i4g which use NVMe local disk